### PR TITLE
Improve pre-commit setup and disconnect handling

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,7 +40,7 @@ repos:
       - id: pyupgrade
         args: [--py39-plus]
   - repo: https://github.com/PyCQA/isort
-    rev: 5.10.1
+    rev: 5.13.2
     hooks:
       - id: isort
   - repo: https://github.com/psf/black
@@ -55,7 +55,7 @@ repos:
           - --ignore-words-list=hass,alot,datas,dof,dur,ether,farenheit,hist,iff,iif,ines,ist,lightsensor,mut,nd,pres,referer,rime,ser,serie,te,technik,ue,uint,visability,wan,wanna,withing,iam,incomfort,ba,haa,pullrequests
           - --quiet-level=2
   - repo: https://github.com/PyCQA/flake8
-    rev: 4.0.1
+    rev: 7.2.0
     hooks:
       - id: flake8
   - repo: https://github.com/pre-commit/mirrors-mypy

--- a/custom_components/yeelight_bt/yeelightbt.py
+++ b/custom_components/yeelight_bt/yeelightbt.py
@@ -16,10 +16,7 @@ from typing import Any, Callable, cast
 from bleak import BleakClient, BleakError, BleakScanner
 from bleak.backends.client import BaseBleakClient
 from bleak.backends.device import BLEDevice
-from bleak_retry_connector import (
-    ble_device_has_changed,
-    establish_connection,
-)
+from bleak_retry_connector import ble_device_has_changed, establish_connection
 
 NOTIFY_UUID = "8f65073d-9f57-4aaa-afea-397d19d5bbeb"
 CONTROL_UUID = "aa7d3f34-2d4f-41e0-807f-52fbf8cf7443"
@@ -264,6 +261,7 @@ class Lamp:
         except BleakError as err:
             _LOGGER.error(f"Disconnection: BleakError: {err}")
         self._conn = Conn.DISCONNECTED
+        self.run_state_changed_cb()
 
     @property
     def mac(self) -> str:
@@ -315,6 +313,7 @@ class Lamp:
                 _LOGGER.error("Send Cmd: Timeout error")
             except BleakError as err:
                 _LOGGER.error(f"Send Cmd: BleakError: {err}")
+            await self.disconnect()
         return False
 
     async def get_state(self) -> None:


### PR DESCRIPTION
## Summary
- update pre-commit hooks so installation works on Python 3.12
- call `run_state_changed_cb()` after disconnect and when a send command fails
- run isort on modified file

## Testing
- `pre-commit run --files custom_components/yeelight_bt/yeelightbt.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_684824a711a0832688e748e28d0f28ac